### PR TITLE
Update Makefile, LIBS after objects or LD fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CC = gcc
-FLAGS = -g -W -Wall -O2 -lusb-1.0 -I/usr/include/libusb-1.0
+FLAGS = -g -W -Wall -O2 -I/usr/include/libusb-1.0
+LIBS = -lusb-1.0
 TARGET = main
 
 SRCFOLDER = src


### PR DESCRIPTION
Order of operations fix. GCC 4.7 can't figure out where libusb goes if it is placed before the object files.
