### PR TITLE
Change u-boot build to a Tag

### DIFF
--- a/tools/uboot.sh
+++ b/tools/uboot.sh
@@ -12,6 +12,7 @@ echo Building custom U-Boot
 git clone git://git.denx.de/u-boot.git /tmp/u-boot
 pushd /tmp/u-boot
   git reset --hard
+  git checkout v2014.07 -b tmp
   wget -c https://raw.githubusercontent.com/ungureanuvladvictor/BBBlfs/master/tools/USB_FLash.patch
   patch -p1 < USB_FLash.patch
   make ARCH=arm CROSS_COMPILE=$CROSS_COMPILE am335x_evm_usbspl_defconfig


### PR DESCRIPTION
The current patch applies cleanly on 2014.07 tag.  It does not apply cleanly on master or any newer tags.

Edit: I meant to send this before but forgot.  So here it is.