### PR TITLE
check to see if compiler is already in path, if so use that instead

### DIFF
--- a/tools/common.sh
+++ b/tools/common.sh
@@ -1,7 +1,11 @@
 echo
-wget -c https://releases.linaro.org/14.04/components/toolchain/binaries/gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux.tar.xz
-tar xf gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux.tar.xz
-export CROSS_COMPILE=`pwd`/gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux/bin/arm-linux-gnueabihf-
+if which arm-linux-gnueabihf-gcc > /dev/null; then
+  export CROSS_COMPILE=arm-linux-gnueabihf-
+else
+  wget -c https://releases.linaro.org/14.04/components/toolchain/binaries/gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux.tar.xz
+  tar xf gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux.tar.xz
+  export CROSS_COMPILE=`pwd`/gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux/bin/arm-linux-gnueabihf-
+fi
 echo The cross compiler is set to $CROSS_COMPILE
 echo
 


### PR DESCRIPTION
NOTE: I haven't try it, but linaro has 4.9 compiler at [linaro](https://releases.linaro.org/14.09/components/toolchain/binaries/gcc-linaro-arm-linux-gnueabihf-4.9-2014.09_linux.tar.xz) did you try using 4.9 of the compiler?