### PR TITLE
Partition resize script needs updating to work with latest images

### DIFF
--- a/bin/flash_script.sh
+++ b/bin/flash_script.sh
@@ -141,7 +141,7 @@ then
 			xzcat $input | sudo dd of=/dev/$bbb bs=1M
 			echo
 			echo "Resizing partitons now, just as a saefty measure if you flash 2GB image on 4GB board!"
-			echo -e "d\n2\nn\np\n2\n\n\nw" | sudo fdisk /dev/$bbb > /dev/null
+			echo -e "d\n2\nn\np\n2\n8192\n\nw" | sudo fdisk /dev/$bbb > /dev/null
 		fi
 		sudo e2fsck -f /dev/${bbb}2
 		sudo resize2fs /dev/${bbb}2

--- a/bin/flash_script.sh
+++ b/bin/flash_script.sh
@@ -140,7 +140,7 @@ then
 		else
 			xzcat $input | sudo dd of=/dev/$bbb bs=1M
 			echo
-			echo "Resizing partitons now, just as a saefty measure if you flash 2GB image on 4GB board!"
+			echo "Resizing partition now, to use all available space."
 			echo -e "d\nn\np\n1\n8192\n\nw" | sudo fdisk /dev/$bbb > /dev/null
 		fi
 		sudo e2fsck -f /dev/${bbb}1

--- a/bin/flash_script.sh
+++ b/bin/flash_script.sh
@@ -141,10 +141,10 @@ then
 			xzcat $input | sudo dd of=/dev/$bbb bs=1M
 			echo
 			echo "Resizing partitons now, just as a saefty measure if you flash 2GB image on 4GB board!"
-			echo -e "d\n2\nn\np\n2\n8192\n\nw" | sudo fdisk /dev/$bbb > /dev/null
+			echo -e "d\nn\np\n1\n8192\n\nw" | sudo fdisk /dev/$bbb > /dev/null
 		fi
-		sudo e2fsck -f /dev/${bbb}2
-		sudo resize2fs /dev/${bbb}2
+		sudo e2fsck -f /dev/${bbb}1
+		sudo resize2fs /dev/${bbb}1
 		echo
         echo "Please remove power from your board and plug it again."\
 				"You will boot in the new OS!"


### PR DESCRIPTION
#Hello,

I've successfully used your work to flash my new BeagleBone with the latest Debian 9 images, [here](https://debian.beagleboard.org/images/bone-debian-9.1-iot-armhf-2017-09-21-4gb.img.xz) and [here](http://debian.beagleboard.org/images/bone-debian-9.1-lxqt-armhf-2017-08-31-4gb.img.xz). Thank you, it was much more convenient than having to use a microSD card!

To work with these new images, I had to change just a few a characters in the script. The commit log should explain it all, but the short version is that these images only have one partition (the root, with /boot as just a subdirectory). It seems that the script was expecting to modify the second of two partitions, and corrupted the partition table as a result.

And I changed the status message, just because there were typos, and I think it's less confusing now (even on my 4GB BeagleBone, resizing made available an additional ~250MiB that was left over after flashing). Obviously, you can decide. The patches are submitted for your consideration. Thanks!