### PR TITLE
fixed issue with: 'libusb_set_debug is deprecated: Use libusb_set_opt…

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -63,7 +63,11 @@ int main(int UNUSED argc, const char UNUSED * argv[]) {
 		printf("Init error!\n");
 		exit(1);
 	}
+#if LIBUSB_API_VERSION >= 0x01000106
+	libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, 3);
+#else
 	libusb_set_debug(ctx, 3);
+#endif
 
 	while (dev_handle == NULL) {
 		r = libusb_get_device_list(ctx, &devs);


### PR DESCRIPTION
fixed issue with `'libusb_set_debug is deprecated: Use libusb_set_option` due to compile warning:
```bash
main.c: In function ‘main’:
main.c:66:2: warning: ‘libusb_set_debug’ is deprecated: Use libusb_set_option instead [-Wdeprecated-declarations]
  libusb_set_debug(ctx, 3);
  ^~~~~~~~~~~~~~~~
In file included from main.c:20:
/usr/include/libusb-1.0/libusb.h:1300:18: note: declared here
 void LIBUSB_CALL libusb_set_debug(libusb_context *ctx, int level);

```